### PR TITLE
Improve env var handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,8 @@ SUPABASE_SERVICE_ROLE_KEY=<your service role key>
 TELEGRAM_TOKEN=<your Telegram bot token>
 ```
 
+Make sure the values are not wrapped in quotes. Any leading or trailing quotes
+or whitespace will be removed automatically at runtime, but providing the exact
+tokens prevents connection errors such as "Invalid API key".
+
 These values are required at startup. The bot will exit with an error if any are missing.

--- a/bot.js
+++ b/bot.js
@@ -2,6 +2,15 @@ require('dotenv').config();
 const { Bot } = require('grammy');
 const { createClient } = require('@supabase/supabase-js');
 
+function getEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing environment variable: ${name}`);
+    process.exit(1);
+  }
+  return value.trim().replace(/^['"]|['"]$/g, '');
+}
+
 // Fail fast if required environment variables are missing
 const requiredEnv = [
   'SUPABASE_URL',
@@ -14,6 +23,7 @@ for (const name of requiredEnv) {
     console.error(`Missing environment variable: ${name}`);
     process.exit(1);
   }
+  process.env[name] = getEnv(name);
 }
 
 const supabaseAuth = createClient(

--- a/server.js
+++ b/server.js
@@ -4,13 +4,23 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const { createClient } = require('@supabase/supabase-js');
 const { Bot } = require('grammy');
-const supabaseAuth = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_ANON_KEY);
+
+function getEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing environment variable: ${name}`);
+    process.exit(1);
+  }
+  return value.trim().replace(/^['"]|['"]$/g, '');
+}
+
+const supabaseAuth = createClient(getEnv('SUPABASE_URL'), getEnv('SUPABASE_ANON_KEY'));
 
 // load env
-const bot = new Bot(process.env.TELEGRAM_TOKEN);
+const bot = new Bot(getEnv('TELEGRAM_TOKEN'));
 const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
+  getEnv('SUPABASE_URL'),
+  getEnv('SUPABASE_SERVICE_ROLE_KEY')
 );
 
 // reuse your existing bot handlers


### PR DESCRIPTION
## Summary
- sanitize env vars before use
- document that `.env` values should not be quoted

## Testing
- `npm test` *(fails: Error: no test specified)*