### PR TITLE
Add exec_sql edge function example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ or whitespace will be removed automatically at runtime, but providing the exact
 tokens prevents connection errors such as "Invalid API key".
 
 These values are required at startup. The bot will exit with an error if any are missing.
+
+## Supabase Edge Function
+
+Deploy the Edge Function in `supabase/functions/exec_sql` so the bot can execute SQL on behalf of the authenticated user. The `/tables` command calls this function with the user's JWT, and your Row Level Security policies are automatically enforced.

--- a/supabase/functions/exec_sql/index.ts
+++ b/supabase/functions/exec_sql/index.ts
@@ -1,0 +1,25 @@
+import { serve } from "https://deno.land/std/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+serve(async (req) => {
+  const jwt = req.headers.get("authorization")?.replace("Bearer ", "");
+  if (!jwt) {
+    return new Response("Missing JWT", { status: 401 });
+  }
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    { global: { headers: { Authorization: `Bearer ${jwt}` } } },
+  );
+
+  const { sql_text, sql_params } = await req.json();
+  const { data, error } = await supabase.rpc("exec_sql", {
+    sql_text,
+    sql_params,
+  });
+
+  return new Response(JSON.stringify({ data, error }), {
+    headers: { "Content-Type": "application/json" },
+  });
+});


### PR DESCRIPTION
## Summary
- add an exec_sql Supabase Edge Function
- document deploying the new edge function

## Testing
- `npm test` *(fails: Error: no test specified)*